### PR TITLE
macOS: auto-select Whisper MPS device and add macOS setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,36 @@ python src/vibevoice/cli.py
 - Python 3.13 or higher
 
 ### System Requirements
-- CUDA-capable GPU (recommended) -> in server.py you can enable cpu use
-- CUDA 12.x
-- cuBLAS
-- cuDNN 9.x
-- In case you get this error: `OSError: PortAudio library not found` run `sudo apt install libportaudio2`
+- Linux/Windows with NVIDIA GPU: CUDA-capable GPU (recommended), CUDA 12.x, cuBLAS, cuDNN 9.x
+- macOS (Apple Silicon): PyTorch + MPS support (Whisper device is auto-set to `mps`)
+- Audio backend: PortAudio (`sudo apt install libportaudio2` on Linux, `brew install portaudio` on macOS)
 - [Ollama](https://ollama.com) for AI command mode (with multimodal models for screenshot support)
+
+
+### macOS setup (MacBook Air / Apple Silicon)
+
+1. Install PortAudio via Homebrew:
+   ```bash
+   brew install portaudio
+   ```
+2. Install Python deps:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Grant keyboard control permissions for `pynput`:
+   - Open **System Settings -> Privacy & Security -> Accessibility**
+   - Enable access for your terminal app (e.g., Terminal, iTerm, Warp)
+4. Run vibevoice:
+   ```bash
+   python src/vibevoice/cli.py
+   ```
+
+By default, `src/vibevoice/server.py` now auto-selects `mps` on macOS and `cuda` elsewhere. You can always override this with:
+
+```bash
+export WHISPER_DEVICE=cpu
+export WHISPER_COMPUTE_TYPE=int8
+```
 
 #### Setting up Ollama
 1. Install Ollama by following the instructions at [ollama.com](https://ollama.com)

--- a/src/vibevoice/server.py
+++ b/src/vibevoice/server.py
@@ -1,5 +1,8 @@
 """FastAPI server for Whisper transcription"""
 
+import os
+import platform
+
 import uvicorn
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -7,9 +10,27 @@ from faster_whisper import WhisperModel
 
 app = FastAPI()
 
-model = WhisperModel("large", device="cuda", compute_type="float16")
-# Enable in case you want to run on CPU, but it's much slower
-#model = WhisperModel("medium", device="cpu", compute_type="int8")
+def _get_whisper_runtime():
+    """Infer a sensible Whisper runtime based on the host OS and env overrides."""
+    device = os.getenv("WHISPER_DEVICE")
+    compute_type = os.getenv("WHISPER_COMPUTE_TYPE")
+
+    if device and compute_type:
+        return device, compute_type
+
+    system = platform.system().lower()
+
+    if system == "darwin":
+        # Apple Silicon (MacBook Air/Pro) should use Metal Performance Shaders.
+        return device or "mps", compute_type or "float16"
+
+    return device or "cuda", compute_type or "float16"
+
+
+WHISPER_DEVICE, WHISPER_COMPUTE_TYPE = _get_whisper_runtime()
+model = WhisperModel("large", device=WHISPER_DEVICE, compute_type=WHISPER_COMPUTE_TYPE)
+# Example CPU fallback:
+# model = WhisperModel("medium", device="cpu", compute_type="int8")
 
 class TranscribeRequest(BaseModel):
     file_path: str


### PR DESCRIPTION
### Motivation
- Make Vibevoice runnable on macOS (Apple Silicon) by selecting a sensible Whisper runtime and documenting macOS-specific steps. 
- Reduce manual edits needed to run on MacBooks (MPS support, PortAudio via Homebrew, and `pynput` accessibility permissions).

### Description
- Add OS-aware runtime selection in `src/vibevoice/server.py` that picks `mps`/`float16` on macOS and `cuda`/`float16` elsewhere, with environment overrides `WHISPER_DEVICE` and `WHISPER_COMPUTE_TYPE`.
- Initialize the `WhisperModel` using the chosen runtime (`WHISPER_DEVICE`, `WHISPER_COMPUTE_TYPE`).
- Update `README.md` with a macOS setup section including `brew install portaudio`, `pip install -r requirements.txt`, `pynput` Accessibility/Accessibility permissions guidance, example run command, and environment variable override examples.
- Files changed: `src/vibevoice/server.py`, `README.md`.

### Testing
- Ran `python -m compileall src/vibevoice/server.py src/vibevoice/cli.py`, which completed successfully.
- No other automated tests were run in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07123fe750832086e5b1997c6136b1)